### PR TITLE
Return 500 error on votes for 💩

### DIFF
--- a/emojivoto/emojivoto-voting-svc/api/api.go
+++ b/emojivoto/emojivoto-voting-svc/api/api.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"context"
-	"google.golang.org/grpc"
+	"fmt"
+
 	pb "github.com/buoyantio/conduit-examples/emojivoto/emojivoto-voting-svc/gen/proto"
 	"github.com/buoyantio/conduit-examples/emojivoto/emojivoto-voting-svc/voting"
+	"google.golang.org/grpc"
 )
 
 type PollServiceServer struct {
@@ -12,21 +14,25 @@ type PollServiceServer struct {
 }
 
 func (pS *PollServiceServer) Vote(context context.Context, req *pb.VoteRequest) (*pb.VoteResponse, error) {
-	err := pS.poll.Vote(req.Shortcode)
-	return nil, err
+	sc := req.Shortcode
+	if sc == ":shit:" || sc == ":poop:" || sc == ":hankey:" {
+		return nil, fmt.Errorf("ERROR")
+	}
+	err := pS.poll.Vote(sc)
+	return &pb.VoteResponse{}, err
 }
 
 func (pS *PollServiceServer) Results(context.Context, *pb.ResultsRequest) (*pb.ResultsResponse, error) {
 	results, e := pS.poll.Results()
 	if e != nil {
-		return &pb.ResultsResponse{}, e
+		return nil, e
 	}
 
 	votingResults := make([]*pb.VotingResult, 0)
 	for _, e := range results {
 		result := pb.VotingResult{
 			Shortcode: e.Shortcode,
-			Votes: int32(e.NumVotes),
+			Votes:     int32(e.NumVotes),
 		}
 		votingResults = append(votingResults, &result)
 	}

--- a/emojivoto/emojivoto-voting-svc/api/api_test.go
+++ b/emojivoto/emojivoto-voting-svc/api/api_test.go
@@ -1,8 +1,9 @@
 package api
 
 import (
-	"testing"
 	"context"
+	"testing"
+
 	pb "github.com/buoyantio/conduit-examples/emojivoto/emojivoto-voting-svc/gen/proto"
 	"github.com/buoyantio/conduit-examples/emojivoto/emojivoto-voting-svc/voting"
 )
@@ -41,7 +42,7 @@ func TestLeaderboard(t *testing.T) {
 		}
 
 		votedForTwice := ":wave:"
-		votedForOnce := ":poop:"
+		votedForOnce := ":ghost:"
 
 		emojivotoService.Vote(ctx, &pb.VoteRequest{Shortcode: votedForTwice})
 		emojivotoService.Vote(ctx, &pb.VoteRequest{Shortcode: votedForTwice})
@@ -57,7 +58,7 @@ func TestLeaderboard(t *testing.T) {
 			t.Fatalf("Expected results to contain two emoji, found: [%v]", response.Results)
 		}
 
-		if response.Results[0].Shortcode != votedForTwice|| response.Results[0].Votes != 2 {
+		if response.Results[0].Shortcode != votedForTwice || response.Results[0].Votes != 2 {
 			t.Fatalf("Expected results to be [%s,%s], found: [%v]", votedForTwice, 2, response.Results)
 		}
 


### PR DESCRIPTION
This updates the voting service to return an error on votes for the 💩 emoji, which triggers the app's new 5xx error page.

In a separate PR I'm going to split out voting service's Vote endpoint into separate endpoints for each eligible emoji, but I wanted to put this up for review sooner so folks could test the integration with the frontend code.