### PR TITLE
Introduce job-based Kubernetes config

### DIFF
--- a/emojivoto-job.yml
+++ b/emojivoto-job.yml
@@ -1,0 +1,181 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: emojivoto
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  creationTimestamp: null
+  name: emoji
+  namespace: emojivoto
+spec:
+  manualSelector: true
+  selector:
+    matchLabels:
+      app: emoji-svc
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: emoji-svc
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - env:
+        - name: GRPC_PORT
+          value: "8080"
+        image: buoyantio/emojivoto-emoji-svc:v6
+        name: emoji-svc
+        ports:
+        - containerPort: 8080
+          name: grpc
+        resources:
+          requests:
+            cpu: 100m
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: emoji-svc
+  namespace: emojivoto
+spec:
+  selector:
+    app: emoji-svc
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  creationTimestamp: null
+  name: voting
+  namespace: emojivoto
+spec:
+  manualSelector: true
+  selector:
+    matchLabels:
+      app: voting-svc
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: voting-svc
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - env:
+        - name: GRPC_PORT
+          value: "8080"
+        image: buoyantio/emojivoto-voting-svc:v6
+        name: voting-svc
+        ports:
+        - containerPort: 8080
+          name: grpc
+        resources:
+          requests:
+            cpu: 100m
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: voting-svc
+  namespace: emojivoto
+spec:
+  selector:
+    app: voting-svc
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  creationTimestamp: null
+  name: web
+  namespace: emojivoto
+spec:
+  manualSelector: true
+  selector:
+    matchLabels:
+      app: web-svc
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: web-svc
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v6
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+        resources:
+          requests:
+            cpu: 100m
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+  namespace: emojivoto
+spec:
+  type: LoadBalancer
+  selector:
+    app: web-svc
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  creationTimestamp: null
+  name: vote-bot
+  namespace: emojivoto
+spec:
+  manualSelector: true
+  selector:
+    matchLabels:
+      app: vote-bot
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: vote-bot
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - command:
+        - emojivoto-vote-bot
+        env:
+        - name: WEB_HOST
+          value: web-svc.emojivoto:80
+        image: buoyantio/emojivoto-web:v6
+        name: vote-bot
+        resources:
+          requests:
+            cpu: 10m
+status: {}
+---


### PR DESCRIPTION
The repo provides Kubernetes configs to deploy emojivoto as Deployments,
DaemonSets, and StatefulSets.

This change introduces an analogous Job config.

Relates to linkerd/linkerd2#2416

Signed-off-by: Andrew Seigner <siggy@buoyant.io>