### PR TITLE
[DNM] Tracing demo with OpenCensus

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,9 +2,33 @@
 
 
 [[projects]]
-  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
+  digest = "1:fc8d3788ad2ceee328fdb526b467f14ee7091ed6b3eca94299b98be17d1219c9"
+  name = "contrib.go.opencensus.io/exporter/ocagent"
+  packages = ["."]
+  pruneopts = ""
+  revision = "a8a6f458bbc1d5042322ad1f9b65eeb0b69be9ea"
+  version = "v0.6.0"
+
+[[projects]]
+  digest = "1:ad70cf78ff17abf96d92a6082f4d3241fef8f149118f87c3a267ed47a08be603"
+  name = "github.com/census-instrumentation/opencensus-proto"
+  packages = [
+    "gen-go/agent/common/v1",
+    "gen-go/agent/metrics/v1",
+    "gen-go/agent/trace/v1",
+    "gen-go/metrics/v1",
+    "gen-go/resource/v1",
+    "gen-go/trace/v1",
+  ]
+  pruneopts = ""
+  revision = "d89fa54de508111353cb0b06403c00569be780d8"
+  version = "v0.2.1"
+
+[[projects]]
+  digest = "1:b852d2b62be24e445fcdbad9ce3015b44c207815d631230dfce3f14e7803f5bf"
   name = "github.com/golang/protobuf"
   packages = [
+    "jsonpb",
     "proto",
     "protoc-gen-go",
     "protoc-gen-go/descriptor",
@@ -15,11 +39,59 @@
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
+    "ptypes/struct",
     "ptypes/timestamp",
+    "ptypes/wrappers",
   ]
   pruneopts = ""
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
+
+[[projects]]
+  digest = "1:4ab82898193e99be9d4f1f1eb4ca3b1113ab6b7b2ff4605198ae305de864f05e"
+  name = "github.com/grpc-ecosystem/grpc-gateway"
+  packages = [
+    "internal",
+    "runtime",
+    "utilities",
+  ]
+  pruneopts = ""
+  revision = "ad529a448ba494a88058f9e5be0988713174ac86"
+  version = "v1.9.5"
+
+[[projects]]
+  digest = "1:7f6f07500a0b7d3766b00fa466040b97f2f5b5f3eef2ecabfe516e703b05119a"
+  name = "github.com/hashicorp/golang-lru"
+  packages = ["simplelru"]
+  pruneopts = ""
+  revision = "7f827b33c0f158ec5dfbba01bb0b14a4541fd81d"
+  version = "v0.5.3"
+
+[[projects]]
+  digest = "1:15322677d41c39ba767c0bcfe258fe2ffeeb1c355069674788418bf9c507e811"
+  name = "go.opencensus.io"
+  packages = [
+    ".",
+    "internal",
+    "internal/tagencoding",
+    "metric/metricdata",
+    "metric/metricproducer",
+    "plugin/ocgrpc",
+    "plugin/ochttp",
+    "plugin/ochttp/propagation/b3",
+    "resource",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+    "trace",
+    "trace/internal",
+    "trace/propagation",
+    "trace/tracestate",
+  ]
+  pruneopts = ""
+  revision = "9c377598961b706d1542bd2d84d538b5094d596e"
+  version = "v0.22.0"
 
 [[projects]]
   branch = "master"
@@ -36,6 +108,14 @@
   ]
   pruneopts = ""
   revision = "915654e7eabcea33ae277abbecf52f0d8b7a9fdc"
+
+[[projects]]
+  branch = "master"
+  digest = "1:9f6efefb4e401a4f699a295d14518871368eb89403f2dd23ec11dfcd2c0836ba"
+  name = "golang.org/x/sync"
+  packages = ["semaphore"]
+  pruneopts = ""
+  revision = "112230192c580c3556b8cee6403af37a4fc5f28c"
 
 [[projects]]
   branch = "master"
@@ -69,10 +149,22 @@
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:e87739b83e54909bd0c631784c654ef83f6c9912b4ebb41cf7d1cacd4ebe6c15"
+  name = "google.golang.org/api"
+  packages = ["support/bundler"]
+  pruneopts = ""
+  revision = "dec2ee309f5b09fc59bc40676447c15736284d78"
+  version = "v0.8.0"
+
+[[projects]]
   branch = "master"
   digest = "1:1aa609a0033ef2927e083f2e5e07203ca35fe21c4a24b563de9fea16ddaae9ba"
   name = "google.golang.org/genproto"
-  packages = ["googleapis/rpc/status"]
+  packages = [
+    "googleapis/api/httpbody",
+    "googleapis/rpc/status",
+    "protobuf/field_mask",
+  ]
   pruneopts = ""
   revision = "db91494dd46c1fdcbbde05e5ff5eb56df8f7d79a"
 
@@ -120,8 +212,12 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "contrib.go.opencensus.io/exporter/ocagent",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go",
+    "go.opencensus.io/plugin/ocgrpc",
+    "go.opencensus.io/plugin/ochttp",
+    "go.opencensus.io/trace",
     "golang.org/x/net/context",
     "google.golang.org/grpc",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,4 +6,4 @@ required = ["github.com/golang/protobuf/protoc-gen-go"]
 
 [[constraint]]
   name = "github.com/golang/protobuf"
-  version = "v1.2.0"
+  version = "v1.3.2"

--- a/emojivoto-voting-svc/cmd/server.go
+++ b/emojivoto-voting-svc/cmd/server.go
@@ -5,14 +5,19 @@ import (
 	"log"
 	"net"
 	"os"
+	"time"
 
 	"github.com/buoyantio/emojivoto/emojivoto-voting-svc/api"
 	"github.com/buoyantio/emojivoto/emojivoto-voting-svc/voting"
 	"google.golang.org/grpc"
+	"contrib.go.opencensus.io/exporter/ocagent"
+	"go.opencensus.io/plugin/ocgrpc"
+	"go.opencensus.io/trace"
 )
 
 var (
-	grpcPort = os.Getenv("GRPC_PORT")
+	grpcPort    = os.Getenv("GRPC_PORT")
+	ocagentHost = os.Getenv("OC_AGENT_HOST")
 )
 
 func main() {
@@ -21,6 +26,19 @@ func main() {
 		log.Fatalf("GRPC_PORT (currently [%s]) environment variable must me set to run the server.", grpcPort)
 	}
 
+	oce, err := ocagent.NewExporter(
+		ocagent.WithInsecure(),
+		ocagent.WithReconnectionPeriod(5 * time.Second),
+		ocagent.WithAddress(ocagentHost),
+		ocagent.WithServiceName("voting"))
+	if err != nil {
+		log.Fatalf("Failed to create ocagent-exporter: %v", err)
+	}
+	trace.RegisterExporter(oce)
+	trace.ApplyConfig(trace.Config{
+		DefaultSampler: trace.AlwaysSample(),
+	})
+
 	poll := voting.NewPoll()
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", grpcPort))
@@ -28,7 +46,7 @@ func main() {
 		panic(err)
 	}
 
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(grpc.StatsHandler(&ocgrpc.ServerHandler{}))
 	api.NewGrpServer(grpcServer, poll)
 	log.Printf("Starting grpc server on GRPC_PORT=[%s]", grpcPort)
 	grpcServer.Serve(lis)

--- a/emojivoto-web/cmd/server.go
+++ b/emojivoto-web/cmd/server.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"log"
+	"time"
 	"os"
 
 	pb "github.com/buoyantio/emojivoto/emojivoto-web/gen/proto"
 	"github.com/buoyantio/emojivoto/emojivoto-web/web"
 	"google.golang.org/grpc"
+	"contrib.go.opencensus.io/exporter/ocagent"
+	"go.opencensus.io/plugin/ocgrpc"
+	"go.opencensus.io/trace"
 )
 
 var (
@@ -15,6 +19,7 @@ var (
 	votingsvcHost        = os.Getenv("VOTINGSVC_HOST")
 	indexBundle          = os.Getenv("INDEX_BUNDLE")
 	webpackDevServerHost = os.Getenv("WEBPACK_DEV_SERVER")
+	ocagentHost          = os.Getenv("OC_AGENT_HOST")
 )
 
 func main() {
@@ -22,6 +27,19 @@ func main() {
 	if webPort == "" || emojisvcHost == "" || votingsvcHost == "" {
 		log.Fatalf("WEB_PORT (currently [%s]) EMOJISVC_HOST (currently [%s]) and VOTINGSVC_HOST (currently [%s]) INDEX_BUNDLE (currently [%s]) environment variables must me set.", webPort, emojisvcHost, votingsvcHost, indexBundle)
 	}
+
+	oce, err := ocagent.NewExporter(
+		ocagent.WithInsecure(),
+		ocagent.WithReconnectionPeriod(5 * time.Second),
+		ocagent.WithAddress(ocagentHost),
+		ocagent.WithServiceName("web"))
+	if err != nil {
+		log.Fatalf("Failed to create ocagent-exporter: %v", err)
+	}
+	trace.RegisterExporter(oce)
+	trace.ApplyConfig(trace.Config{
+		DefaultSampler: trace.AlwaysSample(),
+	})
 
 	votingSvcConn := openGrpcClientConnection(votingsvcHost)
 	votingClient := pb.NewVotingServiceClient(votingSvcConn)
@@ -36,7 +54,7 @@ func main() {
 
 func openGrpcClientConnection(host string) *grpc.ClientConn {
 	log.Printf("Connecting to [%s]", host)
-	conn, err := grpc.Dial(host, grpc.WithInsecure())
+	conn, err := grpc.Dial(host, grpc.WithInsecure(), grpc.WithStatsHandler(new(ocgrpc.ClientHandler)))
 	if err != nil {
 		panic(err)
 	}

--- a/emojivoto.yml
+++ b/emojivoto.yml
@@ -45,7 +45,9 @@ spec:
       - env:
         - name: GRPC_PORT
           value: "8080"
-        image: buoyantio/emojivoto-emoji-svc:v8
+        - name: OC_AGENT_HOST
+          value: "oc-agent.tracing:55678"
+        image: buoyantio/emojivoto-emoji-svc:git-254451a
         name: emoji-svc
         ports:
         - containerPort: 8080
@@ -92,7 +94,9 @@ spec:
       - env:
         - name: GRPC_PORT
           value: "8080"
-        image: buoyantio/emojivoto-voting-svc:v8
+        - name: OC_AGENT_HOST
+          value: "oc-agent.tracing:55678"
+        image: buoyantio/emojivoto-voting-svc:git-254451a
         name: voting-svc
         ports:
         - containerPort: 8080
@@ -139,13 +143,15 @@ spec:
       - env:
         - name: WEB_PORT
           value: "80"
+        - name: OC_AGENT_HOST
+          value: "oc-agent.tracing:55678"
         - name: EMOJISVC_HOST
           value: emoji-svc.emojivoto:8080
         - name: VOTINGSVC_HOST
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v8
+        image: buoyantio/emojivoto-web:git-254451a
         name: web-svc
         ports:
         - containerPort: 80


### PR DESCRIPTION
This is a demonstration of instrumenting Emojivoto with OpenCensus, collecting traces with the OC agent and OC collector, and storing/visualizing those traces with Jaeger.

## Demo

1. Deploy the oc-agent (daemonset), the oc-collector (deployment), and jaeger (deployment) by applying this gist: https://gist.github.com/adleong/df003856f8a4c63f19cb9073b08de287
2. Deploy the instrumented emojivoto app by applying `emojivoto.yml` from this branch.
3. View traces in the jaeger UI which can be accessed with: `kubectl -n tracing port-forward deploy/jaeger 16686`

## Open Questions

We hardcode a Always trace sampling policy, but the emojivoto instances also load their config from the agent.  How do these interact?

The emojivoto instances use the oc-agent service's clusterIP.  This means that they will send traces to a random agent, rather than their node-local one.  