### PR TITLE
make deployments use apiVersion apps/v1

### DIFF
--- a/emojivoto.yml
+++ b/emojivoto.yml
@@ -22,7 +22,7 @@ metadata:
   name: web
   namespace: emojivoto
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -69,7 +69,7 @@ spec:
     port: 8080
     targetPort: 8080
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -116,7 +116,7 @@ spec:
     port: 8080
     targetPort: 8080
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -169,7 +169,7 @@ spec:
     port: 80
     targetPort: 80
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
The emojivoto deployment fails on Kubernetes v1.16.0

As per the [1.16 release notes](https://kubernetes.io/docs/setup/release/notes/#deprecations-and-removals), `apps/v1` is suggested for deployments instead of `apps/v1beta1`

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>