### PR TITLE
Add recommended k8s labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,19 @@ To update the docker images:
     docker push buoyantio/emojivoto-web:v9
     ```
 
-1. Update `emojivoto.yml`, `docker-compose.yml`
+1. Update:
+- `docker-compose.yml`
+- (`kustomize/deployment/emoji.yml`),
+- (`kustomize/deployment/vote-bot.yml`),
+- (`kustomize/deployment/voting.yml`),
+- (`kustomize/deployment/web.yml`),
+1. Distribute to the Linkerd website repo
+
+    ```bash
+    kubectl kustomize kustomize/deployment  > ../website/run.linkerd.io/public/emojivoto.yml
+    kubectl kustomize kustomize/daemonset   > ../website/run.linkerd.io/public/emojivoto-daemonset.yml
+    kubectl kustomize kustomize/statefulset > ../website/run.linkerd.io/public/emojivoto-statefulset.yml
+    ```
 
 ## Prometheus Metrics
 

--- a/kustomize/deployment/emoji.yml
+++ b/kustomize/deployment/emoji.yml
@@ -9,6 +9,10 @@ kind: Deployment
 metadata:
   name: emoji
   namespace: emojivoto
+  labels:
+    app.kubernetes.io/name: emoji
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v9
 spec:
   replicas: 1
   selector:

--- a/kustomize/deployment/vote-bot.yml
+++ b/kustomize/deployment/vote-bot.yml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: vote-bot
   namespace: emojivoto
+  labels:
+    app.kubernetes.io/name: vote-bot
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v9
 spec:
   replicas: 1
   selector:

--- a/kustomize/deployment/voting.yml
+++ b/kustomize/deployment/voting.yml
@@ -9,6 +9,10 @@ kind: Deployment
 metadata:
   name: voting
   namespace: emojivoto
+  labels:
+    app.kubernetes.io/name: voting
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v9
 spec:
   replicas: 1
   selector:

--- a/kustomize/deployment/web.yml
+++ b/kustomize/deployment/web.yml
@@ -9,6 +9,10 @@ kind: Deployment
 metadata:
   name: web
   namespace: emojivoto
+  labels:
+    app.kubernetes.io/name: web
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v9
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Add recommended k8s labels:
- `app.kubernetes.io/name`
- `app.kubernetes.io/part-of`
- `app.kubernetes.io/version`

Also update version bump instructions and add steps around updating the
Linkerd website repo.

Fixes #84

Signed-off-by: Andrew Seigner <siggy@buoyant.io>