### PR TITLE
Add version label to ease SMI TrafficSplit config

### DIFF
--- a/kustomize/deployment/emoji.yml
+++ b/kustomize/deployment/emoji.yml
@@ -18,10 +18,12 @@ spec:
   selector:
     matchLabels:
       app: emoji-svc
+      version: v10
   template:
     metadata:
       labels:
         app: emoji-svc
+        version: v10
     spec:
       serviceAccountName: emoji
       containers:

--- a/kustomize/deployment/vote-bot.yml
+++ b/kustomize/deployment/vote-bot.yml
@@ -12,10 +12,12 @@ spec:
   selector:
     matchLabels:
       app: vote-bot
+      version: v10
   template:
     metadata:
       labels:
         app: vote-bot
+        version: v10
     spec:
       containers:
       - command:

--- a/kustomize/deployment/voting.yml
+++ b/kustomize/deployment/voting.yml
@@ -18,10 +18,12 @@ spec:
   selector:
     matchLabels:
       app: voting-svc
+      version: v10
   template:
     metadata:
       labels:
         app: voting-svc
+        version: v10
     spec:
       serviceAccountName: voting
       containers:

--- a/kustomize/deployment/web.yml
+++ b/kustomize/deployment/web.yml
@@ -18,10 +18,12 @@ spec:
   selector:
     matchLabels:
       app: web-svc
+      version: v10
   template:
     metadata:
       labels:
         app: web-svc
+        version: v10
     spec:
       serviceAccountName: web
       containers:


### PR DESCRIPTION
The SMI `TrafficSplit` resouce makes it easy to configure canary releases
in Linkerd. It relies on a `Service` that resolves to all versions
of an application and each version having their own `Service` that
resolves to only endpoints for that version.

Since the current `Deployment` manifests at https://run.linkerd.io/emojivoto.yml
only include the `app` label, you have to redeploy the service you want
to demo `TrafficSplit` with with a `version` label in order to get it
to work properly.

Adding a `version` label will make it so we do not have to redeploy the
current version.

Signed-off-by: Noah Krause <krausenoah@gmail.com>