### PR TITLE
Support multi-arch

### DIFF
--- a/Dockerfile-multi-arch
+++ b/Dockerfile-multi-arch
@@ -32,7 +32,7 @@ COPY --from=webpack-bundle /emojivoto-build/emojivoto-web/target/ /emojivoto-bui
 FROM build-$svc_name as build
 
 # runtime image
-FROM debian:bullseye
+FROM debian:buster-20200514-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \

--- a/Dockerfile-multi-arch
+++ b/Dockerfile-multi-arch
@@ -5,6 +5,7 @@ FROM --platform=$BUILDPLATFORM golang:1.15.0 as golang
 WORKDIR /emojivoto-build
 
 # install protobuf
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y protobuf-compiler
 RUN go get github.com/golang/protobuf/protoc-gen-go
 
@@ -45,6 +46,7 @@ RUN apt-get update \
 ARG svc_name
 COPY --from=build /emojivoto-build/$svc_name/target/ /usr/local/bin/
 
-# ARG variables arent available for ENTRYPOINT
+# ARG variables are not available for ENTRYPOINT
 ENV SVC_NAME $svc_name
-ENTRYPOINT cd /usr/local/bin && $SVC_NAME
+WORKDIR /usr/local/bin
+ENTRYPOINT $SVC_NAME

--- a/Dockerfile-multi-arch
+++ b/Dockerfile-multi-arch
@@ -5,8 +5,7 @@ FROM --platform=$BUILDPLATFORM golang:1.15.0 as golang
 WORKDIR /emojivoto-build
 
 # install protobuf
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y protobuf-compiler
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y protobuf-compiler
 RUN go get github.com/golang/protobuf/protoc-gen-go
 
 # cache go dependencies

--- a/Dockerfile-multi-arch
+++ b/Dockerfile-multi-arch
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM golang:1.15.0 as golang
 WORKDIR /emojivoto-build
 
 # install protobuf
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y protobuf-compiler
 RUN go get github.com/golang/protobuf/protoc-gen-go
 

--- a/Dockerfile-multi-arch
+++ b/Dockerfile-multi-arch
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM golang:1.15.0 as golang
 WORKDIR /emojivoto-build
 
 # install protobuf
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y protobuf-compiler
+RUN apt-get update && apt-get install -y protobuf-compiler
 RUN go get github.com/golang/protobuf/protoc-gen-go
 
 # cache go dependencies

--- a/Dockerfile-multi-arch
+++ b/Dockerfile-multi-arch
@@ -1,0 +1,50 @@
+ARG svc_name
+
+# go build stage
+FROM --platform=$BUILDPLATFORM golang:1.15.0 as golang
+WORKDIR /emojivoto-build
+
+# install protobuf
+RUN apt-get update && apt-get install -y protobuf-compiler
+RUN go get github.com/golang/protobuf/protoc-gen-go
+
+# cache go dependencies
+COPY go.mod go.sum .
+RUN go mod download
+
+# compile
+COPY . .
+ARG TARGETARCH
+ARG svc_name
+RUN GOARCH=$TARGETARCH make -C $svc_name clean protoc compile
+
+# webpack stage
+FROM --platform=$BUILDPLATFORM node:14-buster as webpack-bundle
+WORKDIR /emojivoto-build
+COPY . .
+RUN make -C emojivoto-web clean webpack package-web
+
+FROM golang as build-emojivoto-emoji-svc
+FROM golang as build-emojivoto-voting-svc
+FROM golang as build-emojivoto-web
+COPY --from=webpack-bundle /emojivoto-build/emojivoto-web/target/ /emojivoto-build/emojivoto-web/target/
+
+FROM build-$svc_name as build
+
+# runtime image
+FROM debian:bullseye
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        dnsutils \
+        iptables \
+        jq \
+        nghttp2 \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG svc_name
+COPY --from=build /emojivoto-build/$svc_name/target/ /usr/local/bin/
+
+# ARG variables arent available for ENTRYPOINT
+ENV SVC_NAME $svc_name
+ENTRYPOINT cd /usr/local/bin && $SVC_NAME

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ voting-svc:
 
 build: web emoji-svc voting-svc
 
+multi-arch:
+	$(MAKE) -C emojivoto-web build-multi-arch
+	$(MAKE) -C emojivoto-emoji-svc build-multi-arch
+	$(MAKE) -C emojivoto-voting-svc build-multi-arch
+
 deploy-to-minikube:
 	$(MAKE) -C emojivoto-web build-container
 	$(MAKE) -C emojivoto-emoji-svc build-container

--- a/README.md
+++ b/README.md
@@ -19,35 +19,35 @@ Deploy the application to Minikube using the Linkerd2 service mesh.
 
 1. Install the `linkerd` CLI
 
-```bash
-curl https://run.linkerd.io/install | sh
-```
+    ```bash
+    curl https://run.linkerd.io/install | sh
+    ```
 
 1. Install Linkerd2
 
-```bash
-linkerd install | kubectl apply -f -
-```
+    ```bash
+    linkerd install | kubectl apply -f -
+    ```
 
 1. View the dashboard!
 
-```bash
-linkerd dashboard
-```
+    ```bash
+    linkerd dashboard
+    ```
 
 1. Inject, Deploy, and Enjoy
 
-```bash
-kubectl kustomize kustomize/deployment | \
-    linkerd inject - | \
-    kubectl apply -f -
-```
+    ```bash
+    kubectl kustomize kustomize/deployment | \
+        linkerd inject - | \
+        kubectl apply -f -
+    ```
 
 1. Use the app!
 
-```bash
-minikube -n emojivoto service web-svc
-```
+    ```bash
+    minikube -n emojivoto service web-svc
+    ```
 
 ### In docker-compose
 
@@ -89,28 +89,31 @@ go run emojivoto-web/cmd/vote-bot/main.go
 
 ## Releasing a new version
 
-To update the docker images:
+To build and push multi-arch docker images:
 
 1. Update the tag name in `common.mk`
-1. Update the base image tags in `Makefile` and `Dockerfile`
-1. Build base docker image `make build-base-docker-image`
-1. Build docker images `make build`
-1. Push the docker images to hub.docker.com
+1. Create the Buildx builder instance
+
+    ```bash
+    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    docker buildx create --name=multiarch-builder --driver=docker-container --use
+    docker buildx inspect multiarch-builder --bootstrap
+    ```
+
+1. Build & push the multi-arch docker images to hub.docker.com
 
     ```bash
     docker login
-    docker push buoyantio/emojivoto-svc-base:v10
-    docker push buoyantio/emojivoto-emoji-svc:v10
-    docker push buoyantio/emojivoto-voting-svc:v10
-    docker push buoyantio/emojivoto-web:v10
+    make multi-arch
     ```
 
 1. Update:
-- `docker-compose.yml`
-- (`kustomize/deployment/emoji.yml`),
-- (`kustomize/deployment/vote-bot.yml`),
-- (`kustomize/deployment/voting.yml`),
-- (`kustomize/deployment/web.yml`),
+    - `docker-compose.yml`
+    - `kustomize/deployment/emoji.yml`
+    - `kustomize/deployment/vote-bot.yml`
+    - `kustomize/deployment/voting.yml`
+    - `kustomize/deployment/web.yml`
+
 1. Distribute to the Linkerd website repo
 
     ```bash

--- a/common.mk
+++ b/common.mk
@@ -18,6 +18,10 @@ package: protoc compile build-container
 build-container:
 	docker build .. -t "buoyantio/$(svc_name):$(IMAGE_TAG)" --build-arg svc_name=$(svc_name)
 
+build-multi-arch:
+	docker buildx build .. -t "buoyantio/$(svc_name):$(IMAGE_TAG)" --build-arg svc_name=$(svc_name) \
+		-f ../Dockerfile-multi-arch --platform linux/amd64,linux/arm64,linux/arm/v7 --push
+
 compile:
 	GOOS=linux go build -v -o $(target_dir)/$(svc_name) cmd/server.go
 


### PR DESCRIPTION
@cpretzer @alpeb 

# Changes

- Create `Dockerfile-multi-arch` with purpose build multi-arch images using multi-stage builds
- New target in Makefile `make multi-arch` to build & push multi-arch images
- Adjust the README instruction on how to release

# Follow-up
- Bump the version to `v11` after this PR merged and the `v11` tag is published in docker hub registry