### PR TITLE
Add HOST_OVERRIDE env var to vote-bot

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1,4 +1,4 @@
-export IMAGE_TAG := v10
+export IMAGE_TAG := v11
 
 .PHONY: package protoc test
 


### PR DESCRIPTION
## What

This change introduces a new `HOST_OVERRIDE` environment variable.

When set, `vote-bot` will send requests to `WEB_HOST`, but its request `Host`
headers will be set to `HOST_OVERRIDE` value.

## Why

When testing an ingress scenario, I wanted to have `vote-bot` go through the
ingress deployment before reaching Emojivoto's `web-svc`.

In order to do this, `vote-bot`'s `WEB_HOST` environment variables needs to
target the ingress service, but the host header on it's requests need to be
`web-svc.emojivoto`.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>