### PR TITLE
Update kubernetes configs to use docker.l5d.io

### DIFF
--- a/kustomize/deployment/emoji.yml
+++ b/kustomize/deployment/emoji.yml
@@ -32,7 +32,7 @@ spec:
           value: "8080"
         - name: PROM_PORT
           value: "8801"
-        image: buoyantio/emojivoto-emoji-svc:v11
+        image: docker.l5d.io/buoyantio/emojivoto-emoji-svc:v11
         name: emoji-svc
         ports:
         - containerPort: 8080

--- a/kustomize/deployment/vote-bot.yml
+++ b/kustomize/deployment/vote-bot.yml
@@ -25,7 +25,7 @@ spec:
         env:
         - name: WEB_HOST
           value: web-svc.emojivoto:80
-        image: buoyantio/emojivoto-web:v11
+        image: docker.l5d.io/buoyantio/emojivoto-web:v11
         name: vote-bot
         resources:
           requests:

--- a/kustomize/deployment/web.yml
+++ b/kustomize/deployment/web.yml
@@ -36,7 +36,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v11
+        image: docker.l5d.io/buoyantio/emojivoto-web:v11
         name: web-svc
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Our current emojivoto configs are bound to the docker.io registry.
https://scarf.sh lets us use custom domains so that if, in the future,
we want to move these images off of Docker Hub, we can do so
transparently without having to update our manifests.

This change updates emojivoto's kubernetes manifests to refer to such a
custom domain, docker.l5d.io.

This change does **not** update any of the development tooling, as build
scripts should continue to reference our dockerhub registry.