### PR TITLE
tracing: use the right service name in emoji svc

### DIFF
--- a/emojivoto-emoji-svc/cmd/server.go
+++ b/emojivoto-emoji-svc/cmd/server.go
@@ -36,7 +36,7 @@ func main() {
 		ocagent.WithInsecure(),
 		ocagent.WithReconnectionPeriod(5*time.Second),
 		ocagent.WithAddress(ocagentHost),
-		ocagent.WithServiceName("voting"))
+		ocagent.WithServiceName("emoji"))
 	if err != nil {
 		log.Fatalf("Failed to create ocagent-exporter: %v", err)
 	}


### PR DESCRIPTION
When tracing is enabled, the `emoji` svc is being incorrectly
marked as `voting` as we seem to use the wrong service name
here causing confusion.

This PR fixes that by using `emoji` in the emoji svc
trace initialization

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>