### PR TITLE
Allow setting Request Rate and Time To Live

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/prometheus/client_golang v1.6.0
 	go.opencensus.io v0.22.3


### PR DESCRIPTION
In order to simulate bursty traffic to the emojivoto, I have added the ability to set two environment variables to control the behaviour of the vote-bot:

REQUEST_RATE (integer): The number of requests per second to send. Default and minimum are 1. If the value of the variable is not a valid positive integer, the request rate is set to 1 as well.

TTL (integer): Number of seconds before vote bot quits successfully. If not set, the input is not a valid positive integer or the value is set to 0, the bot will run continuously.
