### PR TITLE
build(deps): bump base image to debian:bookworm

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This is based off of #151 (sfleen/otel).

This fixes the build.

To build all the images for Linux, run:

```
make -C emojivoto-web compile build-container
make -C emojivoto-emoji-svc compile build-container
make -C emojivoto-voting-svc compile build-container
```